### PR TITLE
refactor(dto): replace spatie/data-transfer-object with plain readonly class

### DIFF
--- a/app/Commands/CheckCommand.php
+++ b/app/Commands/CheckCommand.php
@@ -48,7 +48,7 @@ class CheckCommand extends Command
         $this->filter = now()->subMonths($months)->day(1)->toDateString();
 
         try {
-            $pkg = new PackagistApiPackagePayload($payload->json());
+            $pkg = PackagistApiPackagePayload::fromResponse($payload->json());
             $this->info('Found the package. Type: ' . $pkg->type);
 
             $versions = collect($pkg->versions ?? [])

--- a/app/Dto/PackagistApiPackagePayload.php
+++ b/app/Dto/PackagistApiPackagePayload.php
@@ -2,22 +2,32 @@
 
 namespace App\Dto;
 
-use Spatie\DataTransferObject\Attributes\MapFrom;
-
-class PackagistApiPackagePayload extends \Spatie\DataTransferObject\DataTransferObject
+final readonly class PackagistApiPackagePayload
 {
-    #[MapFrom('package.name')]
-    public string $name = '';
-    #[MapFrom('package.description')]
-    public string $description = '';
-    #[MapFrom('package.time')]
-    public string $time = '';
-    #[MapFrom('package.versions')]
-    public array $versions = [];
-    #[MapFrom('package.type')]
-    public string $type = '';
-    #[MapFrom('package.repository')]
-    public string $repository = '';
-    #[MapFrom('package.language')]
-    public string $language = '';
+    public function __construct(
+        public string $name = '',
+        public string $description = '',
+        public string $time = '',
+        public array $versions = [],
+        public string $type = '',
+        public string $repository = '',
+        public string $language = '',
+    ) {
+    }
+
+    /** Create from the raw Packagist API response array. */
+    public static function fromResponse(array $data): self
+    {
+        $pkg = $data['package'] ?? [];
+
+        return new self(
+            name: $pkg['name'] ?? '',
+            description: $pkg['description'] ?? '',
+            time: $pkg['time'] ?? '',
+            versions: $pkg['versions'] ?? [],
+            type: $pkg['type'] ?? '',
+            repository: $pkg['repository'] ?? '',
+            language: $pkg['language'] ?? '',
+        );
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
   },
   "require": {
     "php": "^8.4",
-    "illuminate/http": "^12.17",
-    "spatie/data-transfer-object": "^3.7"
+    "illuminate/http": "^12.17"
   },
   "require-dev": {
     "captainhook/captainhook": "^5.28",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf1f39464e98b53a5308da63ab9b7094",
+    "content-hash": "6c9155fc6750802789535349ae73a391",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -1724,70 +1724,6 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
-        },
-        {
-            "name": "spatie/data-transfer-object",
-            "version": "3.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/data-transfer-object.git",
-                "reference": "1df0906c4e9e3aebd6c0506fd82c8b7d5548c1c8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/data-transfer-object/zipball/1df0906c4e9e3aebd6c0506fd82c8b7d5548c1c8",
-                "reference": "1df0906c4e9e3aebd6c0506fd82c8b7d5548c1c8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0"
-            },
-            "require-dev": {
-                "illuminate/collections": "^8.36",
-                "jetbrains/phpstorm-attributes": "^1.0",
-                "larapack/dd": "^1.1",
-                "phpunit/phpunit": "^9.5.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\DataTransferObject\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brent Roose",
-                    "email": "brent@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Data transfer objects with batteries included",
-            "homepage": "https://github.com/spatie/data-transfer-object",
-            "keywords": [
-                "data-transfer-object",
-                "spatie"
-            ],
-            "support": {
-                "issues": "https://github.com/spatie/data-transfer-object/issues",
-                "source": "https://github.com/spatie/data-transfer-object/tree/3.9.1"
-            },
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "abandoned": "spatie/laravel-data",
-            "time": "2022-09-16T13:34:38+00:00"
         },
         {
             "name": "symfony/clock",


### PR DESCRIPTION
This pull request refactors how Packagist API package data is handled by removing the dependency on the `spatie/data-transfer-object` package and implementing a custom, readonly data transfer object. This simplifies the codebase and reduces external dependencies.

### Refactoring data transfer object usage

* Replaced the `PackagistApiPackagePayload` class, which previously extended `Spatie\DataTransferObject\DataTransferObject` and used attribute mapping, with a custom, readonly class and a static `fromResponse` constructor for mapping API responses.
* Updated the usage in `CheckCommand.php` to instantiate `PackagistApiPackagePayload` using the new `fromResponse` method instead of the old constructor.

### Dependency cleanup

* Removed the `spatie/data-transfer-object` package from `composer.json` as it is no longer needed.